### PR TITLE
Make the scheme regex stricter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ Build an absolute URL from a relative and base one.
 URLToolkit.buildAbsoluteURL('http://a.com/b/cd', 'e/f/../g'); // => http://a.com/b/e/g
 ```
 
+If you want to ensure that the URL is treated as a relative one you should prefix it with `./`.
+
+```javascript
+URLToolkit.buildAbsoluteURL('http://a.com/b/cd', 'a:b'); // => a:b
+URLToolkit.buildAbsoluteURL('http://a.com/b/cd', './a:b'); // => http://a.com/b/a:b
+```
+
 By default the paths will not be normalized unless necessary, according to the spec. However you can ensure paths are always normalized by setting the `opts.alwaysNormalize` option to `true`.
 
 ```javascript

--- a/src/url-toolkit.js
+++ b/src/url-toolkit.js
@@ -4,7 +4,7 @@
 (function(root) { 
 /* jshint ignore:end */
 
-  var URL_REGEX = /^((?:[^\/;?#]+:)?)(\/\/[^\/\;?#]*)?(.*?)??(;.*?)?(\?.*?)?(#.*?)?$/;
+  var URL_REGEX = /^((?:[a-zA-Z0-9+\-.]+:)?)(\/\/[^\/\;?#]*)?(.*?)??(;.*?)?(\?.*?)?(#.*?)?$/;
   var FIRST_SEGMENT_REGEX = /^([^\/;?#]*)(.*)$/;
   var SLASH_DOT_REGEX = /(?:\/|^)\.(?=\/)/g;
   var SLASH_DOT_DOT_REGEX = /(?:\/|^)\.\.\/(?!\.\.\/).*?(?=\/)/g;

--- a/src/url-toolkit.js
+++ b/src/url-toolkit.js
@@ -14,7 +14,7 @@
     // E.g
     // With opts.alwaysNormalize = false (default, spec compliant)
     // http://a.com/b/cd + /e/f/../g => http://a.com/e/f/../g
-    // With opts.alwaysNormalize = true (default, not spec compliant)
+    // With opts.alwaysNormalize = true (not spec compliant)
     // http://a.com/b/cd + /e/f/../g => http://a.com/e/g
     buildAbsoluteURL: function(baseURL, relativeURL, opts) {
       opts = opts || {};

--- a/test/url-toolkit.js
+++ b/test/url-toolkit.js
@@ -136,6 +136,10 @@ describe('url toolkit', function() {
     test('http://a/b/c/d;p?q', '..', 'http://a/b/');
 
     test('http://a.com/b/cd/e.m3u8?test=1#something', '', 'http://a.com/b/cd/e.m3u8?test=1#something');
+    
+    test('http://a.com/b/cd/e.m3u8?test=1#something', 'a_:b', 'http://a.com/b/cd/a_:b');
+    test('http://a.com/b/cd/e.m3u8?test=1#something', 'a:b', 'a:b');
+    test('http://a.com/b/cd/e.m3u8?test=1#something', './a:b', 'http://a.com/b/cd/a:b');
   });
 });
 


### PR DESCRIPTION
It now must match `[a-zA-Z0-9+\-.]` as described in the RFC.

This means relative urls that happen to contain ‘:’ are more likely to be recognised as relative providing they contain a character that does not satisfy the above.