### PR TITLE
restructure types

### DIFF
--- a/src/url-toolkit.d.ts
+++ b/src/url-toolkit.d.ts
@@ -1,25 +1,22 @@
 export as namespace URLToolkit;
 
-declare namespace URLToolkit {
-  export type URLParts = {
-    scheme: string;
-    netLoc: string;
-    path: string;
-    params: string;
-    query: string;
-    fragment: string;
-  };
-}
-
-declare var URLToolkit: {
-  buildAbsoluteURL: (
-    baseURL: string,
-    relativeURL: string,
-    opts?: { alwaysNormalize?: boolean }
-  ) => string;
-  parseURL: (url: string) => URLToolkit.URLParts | null;
-  normalizePath: (path: string) => string;
-  buildURLFromParts: (parts: URLToolkit.URLParts) => string;
+export type URLParts = {
+  scheme: string;
+  netLoc: string;
+  path: string;
+  params: string;
+  query: string;
+  fragment: string;
 };
 
-export = URLToolkit;
+export function buildAbsoluteURL(
+  baseURL: string,
+  relativeURL: string,
+  opts?: { alwaysNormalize?: boolean }
+): string;
+
+export function parseURL(url: string): URLParts | null;
+
+export function normalizePath(path: string): string;
+
+export function buildURLFromParts(parts: URLParts): string;


### PR DESCRIPTION
Just a restructure of the types to use `export as namespace` as it was intended. Should be no real changes.