### PR TITLE
use `[^]` instead of `.`

### DIFF
--- a/src/url-toolkit.js
+++ b/src/url-toolkit.js
@@ -1,8 +1,8 @@
 // see https://tools.ietf.org/html/rfc1808
 
 (function (root) {
-  var URL_REGEX = /^((?:[a-zA-Z0-9+\-.]+:)?)(\/\/[^\/?#]*)?((?:[^\/?#]*\/)*[^;?#]*)?(;[^?#]*)?(\?[^#]*)?(#.*)?$/;
-  var FIRST_SEGMENT_REGEX = /^([^\/?#]*)(.*)$/;
+  var URL_REGEX = /^((?:[a-zA-Z0-9+\-.]+:)?)(\/\/[^\/?#]*)?((?:[^\/?#]*\/)*[^;?#]*)?(;[^?#]*)?(\?[^#]*)?(#[^]*)?$/;
+  var FIRST_SEGMENT_REGEX = /^([^\/?#]*)([^]*)$/;
   var SLASH_DOT_REGEX = /(?:\/|^)\.(?=\/)/g;
   var SLASH_DOT_DOT_REGEX = /(?:\/|^)\.\.\/(?!\.\.\/)[^\/]*(?=\/)/g;
 

--- a/test/url-toolkit.js
+++ b/test/url-toolkit.js
@@ -293,6 +293,8 @@ describe('url toolkit', () => {
 
     test('http://0.0.0.0/a/b.c', 'd', 'http://0.0.0.0/a/d');
     test('http://[0:0:0:0::0]/a/b.c', 'd', 'http://[0:0:0:0::0]/a/d');
+
+    test('http://example.com/', 'a#\nb', 'http://example.com/a#\nb');
   });
 });
 


### PR DESCRIPTION
because `.` doesn't actually match all characters